### PR TITLE
chore: limit to Node >=9.4.0 || >8.9.4 <9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,13 +23,13 @@ workflows:
   version: 2
   tests:
     jobs:
-      - node8:
-          filters: *release_tags
+      # - node8:
+      #     filters: *release_tags
       - node9:
           filters: *release_tags
       - publish_npm:
           requires:
-            - node8
+            # - node8
             - node9
           filters:
             branches:
@@ -37,11 +37,11 @@ workflows:
             <<: *release_tags
 
 jobs:
-  node8:
-    docker:
-      - image: node:8
-        user: node
-    <<: *unit_tests
+  # node8:
+  #   docker:
+  #     - image: node:8
+  #       user: node
+  #   <<: *unit_tests
   node9:
     docker:
       - image: node:9
@@ -50,7 +50,7 @@ jobs:
 
   publish_npm:
     docker:
-      - image: node:8
+      - image: node:9
         user: node
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ supports automatic server-push.
 
 For more details, see the `h2-auto-push` package.
 
+**This package currently works only with Node >=9.4.0.**
+
 ## How to use
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cookie": "^0.3.1",
     "fastify": "^0.39.1",
     "fastify-plugin": "^0.2.1",
-    "h2-auto-push": "^0.1.0",
+    "h2-auto-push": "^0.2.0",
     "send": "^0.16.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "posttest": "npm run check && npm run license-check",
     "license-check": "jsgl --local ."
   },
+  "engines": {
+    "node": ">=9.4.0 || >8.9.4 <9"
+  },
   "keywords": [
     "http2",
     "auto-push",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-auto-push",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "HTTP/2 auto-push middleware for fastify",
   "main": "build/src/index.js",
   "types": "build/src/index",


### PR DESCRIPTION
There was a breaking change in http2 with Node 9.4.0. A similar change
will be made in Node 8 too.

Temporarily disable CircleCI tests with Node 8. And also update README
with the info.