### PR TITLE
chore: move `fastify` from dependencies to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-auto-push",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -86,6 +86,12 @@
       "integrity": "sha512-64Uv+8bTRVZHlbB8eXQgMP9HguxPgnOOIYrQpwHWrtLDrtcG/lILKhUl7bV65NSOIJ9dXGYD7skQFXzhL8tk1A==",
       "dev": true
     },
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
+      "dev": true
+    },
     "@types/get-port": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@types/get-port/-/get-port-3.2.0.tgz",
@@ -99,16 +105,19 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.0.47",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.47.tgz",
-      "integrity": "sha512-kOwL746WVvt/9Phf6/JgX/bsGQvbrK5iUgzyfwZNcKVFcjAUVSpF9HxevLTld2SG9aywYHOILj38arDdY1r/iQ=="
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.1.tgz",
+      "integrity": "sha512-9ESUxmXt1Isc1xKfDBZ7tpULyTPY5ZCywcfvQTXoLUqP+n4D+MBH+0n75hdzrcmfCc3eWByOi27+GLmMuAvcUA==",
+      "dev": true
     },
     "@types/pino": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-4.7.0.tgz",
-      "integrity": "sha512-aPHbxwzPb6xjT6nXEQevAZPvxM7niraWxFcxxk15ZMXJkYZVaQbTePMP/Yucu1diQADfGQJEGxhVvTxESQFCfA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-4.7.1.tgz",
+      "integrity": "sha512-jatsMBAonuhTB1NhJsbDjvw7p71q3AvHii276OifMQ1RAE9NaX1EEmcG1lxONA1bQIYKjJbTJIj5UHicnYYDPA==",
+      "dev": true,
       "requires": {
-        "@types/node": "8.0.47"
+        "@types/events": "1.1.0",
+        "@types/node": "9.4.1"
       }
     },
     "@types/send": {
@@ -118,13 +127,14 @@
       "dev": true,
       "requires": {
         "@types/mime": "2.0.0",
-        "@types/node": "8.0.47"
+        "@types/node": "9.4.1"
       }
     },
     "abstract-logging": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-1.0.0.tgz",
-      "integrity": "sha1-i33q/TEFWbwo93ck3RuzAXcnjBs="
+      "integrity": "sha1-i33q/TEFWbwo93ck3RuzAXcnjBs=",
+      "dev": true
     },
     "ajv": {
       "version": "4.11.8",
@@ -161,6 +171,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+      "dev": true,
       "requires": {
         "color-convert": "1.9.0"
       }
@@ -637,6 +648,16 @@
             "read-pkg": "2.0.0"
           }
         }
+      }
+    },
+    "avvio": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-5.3.0.tgz",
+      "integrity": "sha512-4LDQxckZh+9Z8DNeSpRr5uzx4Y12kOFwXgDfgoFq93vk9e8gcnYIYq2LoeXCRTJn2KRFX5t7oIbUzYdbVqf9ag==",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0",
+        "fastq": "1.5.0"
       }
     },
     "aws-sign2": {
@@ -1326,6 +1347,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
       "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
@@ -1466,6 +1488,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1473,7 +1496,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.5",
@@ -1577,7 +1601,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -1653,6 +1678,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -1770,9 +1796,10 @@
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
     },
     "end-of-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
       "requires": {
         "once": "1.4.0"
       }
@@ -1806,7 +1833,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "espower-location-detector": {
       "version": "1.0.0",
@@ -1920,7 +1948,8 @@
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
     },
     "fast-diff": {
       "version": "1.1.2",
@@ -1928,99 +1957,74 @@
       "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
       "dev": true
     },
-    "fast-iterator": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fast-iterator/-/fast-iterator-0.2.1.tgz",
-      "integrity": "sha512-APmMxsY5Lo7LHmuULf9xbnKbwFkAQPUOo2+eo9NnnmR3PnLqe4IIMlHevqwl6PdahTE/Uv16U2s5ffsC7Ys3jA==",
-      "requires": {
-        "reusify": "1.0.3"
-      }
-    },
     "fast-json-parse": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
-      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw=="
+      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
-    "fast-safe-stringify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-1.2.1.tgz",
-      "integrity": "sha512-g2UqeO0yyYjTSpiH4zJQk+IycRxyYRABjSf+TpmeMOn9uByzFIoX0y/HnweCFhKb+uuPwjIvqXuK/LTteEBhow=="
-    },
-    "fastify": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-0.39.1.tgz",
-      "integrity": "sha512-bOf1MPzXWLZpwS3l9vJQzW8G/PdMljRTKJsAMg3ykudknkQ0HXFI+h+L9g4XCjlLsqGNvFXBZ2VwXkYF/SsOgg==",
+    "fast-json-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-1.0.0.tgz",
+      "integrity": "sha512-4qpMIL388PITAQszTIURR77ygCvyP7P+ZP5ngeBYFVBPWAtU/o9HXGaZgbrN6FiBZzhc+WNr47YYWa7MqhXk5A==",
+      "dev": true,
       "requires": {
-        "@types/node": "8.5.8",
-        "@types/pino": "4.7.0",
-        "abstract-logging": "1.0.0",
-        "ajv": "6.0.1",
-        "avvio": "4.0.1",
-        "fast-iterator": "0.2.1",
-        "fast-json-stringify": "0.17.0",
-        "find-my-way": "1.8.2",
-        "flatstr": "1.0.5",
-        "light-my-request": "2.0.1",
-        "middie": "3.0.0",
-        "pino": "4.10.2",
-        "pump": "2.0.0"
+        "ajv": "6.1.1"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "8.5.8",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
-          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg=="
-        },
         "ajv": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.0.1.tgz",
-          "integrity": "sha1-KJhYCp8971+chd/q16IiPvE889o=",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",
+          "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
+          "dev": true,
           "requires": {
             "fast-deep-equal": "1.0.0",
             "fast-json-stable-stringify": "2.0.0",
             "json-schema-traverse": "0.3.1"
           }
-        },
-        "avvio": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/avvio/-/avvio-4.0.1.tgz",
-          "integrity": "sha512-Vaga4uQkddyK3OQydLmOb4FubSxsZ7rmXX+n+JwBNEriidXNixAPVEClHEQp70xXSoY/JOLlGDM3gtRkvTcc6A==",
+        }
+      }
+    },
+    "fast-safe-stringify": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-1.2.3.tgz",
+      "integrity": "sha512-QJYT/i0QYoiZBQ71ivxdyTqkwKkQ0oxACXHYxH2zYHJEgzi2LsbjgvtzTbLi1SZcF190Db2YP7I7eTsU2egOlw==",
+      "dev": true
+    },
+    "fastify": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-0.43.0.tgz",
+      "integrity": "sha512-jlVWFTOaeIwDs48GE6t0XmWJuCGPtF/OG/QsygzbRZOeVZKjzMw5SYTPouRBgcodXIAFt1vKZ0Iq7oF8/jwC1Q==",
+      "dev": true,
+      "requires": {
+        "@types/pino": "4.7.1",
+        "abstract-logging": "1.0.0",
+        "ajv": "6.1.1",
+        "avvio": "5.3.0",
+        "end-of-stream": "1.4.1",
+        "fast-json-stringify": "1.0.0",
+        "find-my-way": "1.10.1",
+        "flatstr": "1.0.5",
+        "light-my-request": "2.0.1",
+        "middie": "3.1.0",
+        "pino": "4.10.4"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",
+          "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
+          "dev": true,
           "requires": {
-            "debug": "3.1.0",
-            "fastq": "1.5.0"
-          }
-        },
-        "fast-json-stringify": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-0.17.0.tgz",
-          "integrity": "sha512-u6d857jtxcTTm00UIFDO6jCB3R/c0AzH89AxU3rI1twmkVPAHo/riUGH20UaDOMem9YXwcKrnoX6pF2dG3xlHA==",
-          "requires": {
-            "ajv": "6.0.1",
-            "fast-safe-stringify": "1.2.1"
-          }
-        },
-        "light-my-request": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-2.0.1.tgz",
-          "integrity": "sha512-dzUvlQEsh1zUhxv9262O9u8cDQavHt4YUXWQB0XuiYOVq7k+IRJ5VOWu1duFTP4ly/N2eMIiJLyiEOh1iZy0IQ==",
-          "requires": {
-            "ajv": "6.0.1",
-            "readable-stream": "2.3.3",
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "middie": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/middie/-/middie-3.0.0.tgz",
-          "integrity": "sha512-1Hh9aGe5w+73+v+J4wCFlZEiF/a1ATi477rc6Be1qjAeoQHgMapkS2oGqUf+z93jw3ZfC7G34/e6JpTphCfhJQ==",
-          "requires": {
-            "path-to-regexp": "2.1.0",
-            "reusify": "1.0.3"
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         }
       }
@@ -2033,12 +2037,22 @@
         "semver": "5.4.1"
       }
     },
+    "fastify-static": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/fastify-static/-/fastify-static-0.7.0.tgz",
+      "integrity": "sha512-MBKZWJEwRBTyyTmUjprApjXcc2T6LFJdSDuS54hDdOkW8RrpXqgqAUg4vZmcET6B7kchYJNENiLGx/tjBxfovQ==",
+      "requires": {
+        "fastify-plugin": "0.2.1",
+        "send": "0.16.1"
+      }
+    },
     "fastq": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.5.0.tgz",
       "integrity": "sha1-BeMv+5mewtlF3aJ0Yb8IlBQ2RIs=",
+      "dev": true,
       "requires": {
-        "reusify": "1.0.3"
+        "reusify": "1.0.4"
       }
     },
     "figures": {
@@ -2081,9 +2095,10 @@
       }
     },
     "find-my-way": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-1.8.2.tgz",
-      "integrity": "sha512-RfJ75cVg1AD7OGez39M8rDFzbruCVV2xZk4FWOvXom3W3PHWl1BhOH3mazF+e52Agcxa+VEZu4X2tY8B1E3Ilw=="
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-1.10.1.tgz",
+      "integrity": "sha512-N3SCui48+ZDvRT6cuarjrhaWP2H2zBXzMENu00G+gLqG0e9rgj2WM2tiVkVU2mRUyZzHZ/9CbzIncFziNLWCGQ==",
+      "dev": true
     },
     "find-up": {
       "version": "2.1.0",
@@ -2097,7 +2112,8 @@
     "flatstr": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.5.tgz",
-      "integrity": "sha1-W0UbCMvUji6sVKK74L9GFlqhS+M="
+      "integrity": "sha1-W0UbCMvUji6sVKK74L9GFlqhS+M=",
+      "dev": true
     },
     "fn-name": {
       "version": "2.0.1",
@@ -3229,9 +3245,9 @@
       }
     },
     "h2-auto-push": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/h2-auto-push/-/h2-auto-push-0.1.0.tgz",
-      "integrity": "sha512-aK35hhtm+C0kALjHSdu1UCQB1fwg94ZQPvFBXypotqWNVBux80b4xlbKPlFOjdt4e6akTvPeEwHKICXNqAE7yw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/h2-auto-push/-/h2-auto-push-0.2.0.tgz",
+      "integrity": "sha512-t3B1LKtLPuaM8DXjdpY0tjYCprW97ZyU/BWOePCgxbucwlbrpmhxp4h4gVmiiVURgkIYJCaNB/YK2kFJHmtKiw==",
       "requires": {
         "bloomfilter": "0.0.16"
       }
@@ -3278,7 +3294,8 @@
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
     },
     "has-yarn": {
       "version": "1.0.0",
@@ -3676,7 +3693,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -3793,7 +3811,8 @@
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -3867,6 +3886,30 @@
       "dev": true,
       "requires": {
         "package-json": "4.0.1"
+      }
+    },
+    "light-my-request": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-2.0.1.tgz",
+      "integrity": "sha512-dzUvlQEsh1zUhxv9262O9u8cDQavHt4YUXWQB0XuiYOVq7k+IRJ5VOWu1duFTP4ly/N2eMIiJLyiEOh1iZy0IQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "6.1.1",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",
+          "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
       }
     },
     "load-json-file": {
@@ -4055,6 +4098,16 @@
         "object.omit": "2.0.1",
         "parse-glob": "3.0.4",
         "regex-cache": "0.4.4"
+      }
+    },
+    "middie": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/middie/-/middie-3.1.0.tgz",
+      "integrity": "sha512-673tjCpr9xbI30cVqNbCvBe1hNS4pNs7Fi8Yp9wPiqX3qTpuRm87uD3aRtH9ji7Gt8SavbX7cwYMqY2muIPMJw==",
+      "dev": true,
+      "requires": {
+        "path-to-regexp": "2.1.0",
+        "reusify": "1.0.4"
       }
     },
     "mime-db": {
@@ -5855,6 +5908,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -6002,7 +6056,8 @@
     "path-to-regexp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.1.0.tgz",
-      "integrity": "sha512-dZY7QPCPp5r9cnNuQ955mOv4ZFVDXY/yvqeV7Y1W2PJA3PEFcuow9xKFfJxbBj1pIjOAP+M2B4/7xubmykLrXw=="
+      "integrity": "sha512-dZY7QPCPp5r9cnNuQ955mOv4ZFVDXY/yvqeV7Y1W2PJA3PEFcuow9xKFfJxbBj1pIjOAP+M2B4/7xubmykLrXw==",
+      "dev": true
     },
     "path-type": {
       "version": "3.0.0",
@@ -6041,28 +6096,18 @@
       }
     },
     "pino": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-4.10.2.tgz",
-      "integrity": "sha512-hNNDgOju2UvK4iKqXR3ZwEutoOujBRN9jfQgty/X4B3q1QOqpWqvmVn+GT/a20o8Jw5Wd7VkGJAdgFQg55a+mw==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-4.10.4.tgz",
+      "integrity": "sha512-icde8CYdLyHW+wLIlobDAnoyuQrDnrK055AkczNCo3sf6SZbJ0As0Xh1XHlWQ2K6qsWW4BdMv4kikL/NAoLjCQ==",
+      "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "fast-json-parse": "1.0.3",
-        "fast-safe-stringify": "1.2.1",
+        "fast-safe-stringify": "1.2.3",
         "flatstr": "1.0.5",
-        "pump": "1.0.3",
-        "quick-format-unescaped": "1.1.1",
+        "pump": "2.0.1",
+        "quick-format-unescaped": "1.1.2",
         "split2": "2.2.0"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-          "requires": {
-            "end-of-stream": "1.4.0",
-            "once": "1.4.0"
-          }
-        }
       }
     },
     "pkg-conf": {
@@ -6124,7 +6169,8 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -6133,11 +6179,12 @@
       "dev": true
     },
     "pump": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.0.tgz",
-      "integrity": "sha512-6MYypjOvtiXhBSTOD0Zs5eNjCGfnqi5mPsCsW+dgKTxrZzQMZQNpBo3XRkLx7id753f3EeyHLBqzqqUymIolgw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "dev": true,
       "requires": {
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "once": "1.4.0"
       }
     },
@@ -6154,11 +6201,12 @@
       "dev": true
     },
     "quick-format-unescaped": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-1.1.1.tgz",
-      "integrity": "sha1-53VV7z5m4QXUA54T73kgEoT+6RY=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-1.1.2.tgz",
+      "integrity": "sha1-DKWB3jF0vs7yWsPC6JVjQjgdtpg=",
+      "dev": true,
       "requires": {
-        "fast-safe-stringify": "1.2.1"
+        "fast-safe-stringify": "1.2.3"
       }
     },
     "quick-lru": {
@@ -6250,6 +6298,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -6455,9 +6504,10 @@
       }
     },
     "reusify": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.3.tgz",
-      "integrity": "sha512-t8ZQIaf4CHxy8mb4QddDuGOygGiSSiJHMZrtrC+4E7urVtqON4dHVwmV0gfiBOE1tt5p1puae6o8e0b3wkr1Ag=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
     },
     "rimraf": {
       "version": "2.6.2",
@@ -6495,7 +6545,8 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
     },
     "semver": {
       "version": "5.4.1",
@@ -6697,6 +6748,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "dev": true,
       "requires": {
         "through2": "2.0.3"
       }
@@ -6756,6 +6808,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -6812,6 +6865,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
       "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+      "dev": true,
       "requires": {
         "has-flag": "2.0.0"
       }
@@ -6847,6 +6901,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "dev": true,
       "requires": {
         "readable-stream": "2.3.3",
         "xtend": "4.0.1"
@@ -7087,7 +7142,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "uuid": {
       "version": "3.2.1",
@@ -7197,7 +7253,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "2.3.0",
@@ -7251,7 +7308,8 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   },
   "dependencies": {
     "cookie": "^0.3.1",
-    "fastify": "^0.43.0",
     "fastify-plugin": "^0.2.1",
     "fastify-static": "^0.7.0",
     "h2-auto-push": "^0.2.0"
@@ -58,6 +57,7 @@
     "@types/send": "^0.14.4",
     "ava": "^0.24.0",
     "codecov": "^3.0.0",
+    "fastify": "^0.43.0",
     "get-port": "^3.2.0",
     "gts": "^0.5.3",
     "js-green-licenses": "^0.3.1",


### PR DESCRIPTION
It is needed only for type information and not needed at run-time.