### PR TITLE
feat: use a unique symbol to store request path in the stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,64 @@
         "arrify": "1.0.1"
       }
     },
+    "@ladjs/time-require": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@ladjs/time-require/-/time-require-0.1.4.tgz",
+      "integrity": "sha512-weIbJqTMfQ4r1YX85u54DKfjLZs2jwn1XZ6tIOP/pFgMwhIN5BAtaCp/1wn9DzyLsDR9tW0R2NIePcVJ45ivQQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "0.4.0",
+        "date-time": "0.1.1",
+        "pretty-ms": "0.2.2",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "1.0.0",
+            "has-color": "0.1.7",
+            "strip-ansi": "0.1.1"
+          }
+        },
+        "date-time": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
+          "integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
+          "dev": true
+        },
+        "parse-ms": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
+          "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
+          "dev": true
+        },
+        "pretty-ms": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
+          "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
+          "dev": true,
+          "requires": {
+            "parse-ms": "0.1.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+          "dev": true
+        }
+      }
+    },
     "@types/cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.1.tgz",
@@ -298,15 +356,16 @@
       "dev": true
     },
     "ava": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/ava/-/ava-0.24.0.tgz",
-      "integrity": "sha512-o/ykNzsWB5qgh1cR9jzVw0E1y4E219aXl9njNFGSamSCsD7VhPd3aoZabNZuG1PSVMZmQ8RuwKnTuz/loNhKnw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ava/-/ava-0.25.0.tgz",
+      "integrity": "sha512-4lGNJCf6xL8SvsKVEKxEE46se7JAUIAZoKHw9itTQuwcsydhpAMkBs5gOOiWiwt0JKNIuXWc2/r4r8ZdcNrBEw==",
       "dev": true,
       "requires": {
         "@ava/babel-preset-stage-4": "1.1.0",
         "@ava/babel-preset-transform-test-files": "3.0.0",
         "@ava/write-file-atomic": "2.2.0",
         "@concordance/react": "1.0.0",
+        "@ladjs/time-require": "0.1.4",
         "ansi-escapes": "3.0.0",
         "ansi-styles": "3.2.0",
         "arr-flatten": "1.1.0",
@@ -328,7 +387,7 @@
         "cli-spinners": "1.1.0",
         "cli-truncate": "1.1.0",
         "co-with-promise": "4.6.0",
-        "code-excerpt": "2.1.0",
+        "code-excerpt": "2.1.1",
         "common-path-prefix": "1.0.0",
         "concordance": "3.0.0",
         "convert-source-map": "1.5.1",
@@ -353,7 +412,6 @@
         "is-obj": "1.0.1",
         "is-observable": "1.1.0",
         "is-promise": "2.1.0",
-        "js-yaml": "3.10.0",
         "last-line-stream": "1.0.0",
         "lodash.clonedeepwith": "4.5.0",
         "lodash.debounce": "4.0.8",
@@ -381,8 +439,8 @@
         "stack-utils": "1.0.1",
         "strip-ansi": "4.0.0",
         "strip-bom-buf": "1.0.0",
+        "supertap": "1.0.0",
         "supports-color": "5.1.0",
-        "time-require": "0.1.2",
         "trim-off-newlines": "1.0.1",
         "unique-temp-dir": "1.0.0",
         "update-notifier": "2.3.0"
@@ -402,6 +460,15 @@
           "requires": {
             "camelcase": "2.1.1",
             "map-obj": "1.0.1"
+          }
+        },
+        "code-excerpt": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.1.tgz",
+          "integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
+          "dev": true,
+          "requires": {
+            "convert-to-spaces": "1.0.2"
           }
         },
         "find-up": {
@@ -1458,15 +1525,6 @@
         "pinkie-promise": "1.0.0"
       }
     },
-    "code-excerpt": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.0.tgz",
-      "integrity": "sha1-XcwIHoj0p+O1VOnjXX7yMtR/gUc=",
-      "dev": true,
-      "requires": {
-        "convert-to-spaces": "1.0.2"
-      }
-    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -2038,9 +2096,9 @@
       }
     },
     "fastify-static": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/fastify-static/-/fastify-static-0.7.0.tgz",
-      "integrity": "sha512-MBKZWJEwRBTyyTmUjprApjXcc2T6LFJdSDuS54hDdOkW8RrpXqgqAUg4vZmcET6B7kchYJNENiLGx/tjBxfovQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/fastify-static/-/fastify-static-0.8.0.tgz",
+      "integrity": "sha512-AyRuNUMWwtNPWTeWBrysL6Woi8PY86fGkoCWpAb8UsBocF6gduk/RwtITfj8Vif2CxpBtHZk8xGgm3Ef3PjLvQ==",
       "requires": {
         "fastify-plugin": "0.2.1",
         "send": "0.16.1"
@@ -3245,9 +3303,9 @@
       }
     },
     "h2-auto-push": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/h2-auto-push/-/h2-auto-push-0.2.0.tgz",
-      "integrity": "sha512-t3B1LKtLPuaM8DXjdpY0tjYCprW97ZyU/BWOePCgxbucwlbrpmhxp4h4gVmiiVURgkIYJCaNB/YK2kFJHmtKiw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/h2-auto-push/-/h2-auto-push-0.3.0.tgz",
+      "integrity": "sha512-Stj2Eq6/ud1RdPHvtVn8C5Pue7J8mPArHOuf5wIqPS+Z8H8Tsj2JUOaDZmOu11EJxlRpEWxhUaAsPePZX55k8Q==",
       "requires": {
         "bloomfilter": "0.0.16"
       }
@@ -3718,9 +3776,9 @@
       "dev": true
     },
     "js-green-licenses": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.3.1.tgz",
-      "integrity": "sha512-pFWoi11NZuQPt0emRrQKVi+DVjLUYSE+v/cbMzWIrce+2CvkQ5PQUHwJwXua835Q4RpJMe2BxR66VU7BC1Tusg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.4.0.tgz",
+      "integrity": "sha512-LpkL/9coWxNUmJ9/jxng3uvcLK6Qso2yaz7QBjO+atwtX/xmt8MrCtbkolYdhPZl/fq5dRs7Q7BLA8Ne3DKZ2w==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -6597,6 +6655,12 @@
         }
       }
     },
+    "serialize-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
+      "dev": true
+    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
@@ -6861,6 +6925,19 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "supertap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supertap/-/supertap-1.0.0.tgz",
+      "integrity": "sha512-HZJ3geIMPgVwKk2VsmO5YHqnnJYl6bV5A9JW2uzqV43WmpgliNEYbuvukfor7URpaqpxuw3CfZ3ONdVbZjCgIA==",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "indent-string": "3.2.0",
+        "js-yaml": "3.10.0",
+        "serialize-error": "2.1.0",
+        "strip-ansi": "4.0.0"
+      }
+    },
     "supports-color": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
@@ -6905,64 +6982,6 @@
       "requires": {
         "readable-stream": "2.3.3",
         "xtend": "4.0.1"
-      }
-    },
-    "time-require": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/time-require/-/time-require-0.1.2.tgz",
-      "integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
-      "dev": true,
-      "requires": {
-        "chalk": "0.4.0",
-        "date-time": "0.1.1",
-        "pretty-ms": "0.2.2",
-        "text-table": "0.2.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
-          }
-        },
-        "date-time": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
-          "integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
-          "dev": true
-        },
-        "parse-ms": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
-          "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
-          "dev": true
-        },
-        "pretty-ms": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
-          "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
-          "dev": true,
-          "requires": {
-            "parse-ms": "0.1.2"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-          "dev": true
-        }
       }
     },
     "time-zone": {
@@ -7070,9 +7089,9 @@
       "optional": true
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
+      "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
       "dev": true
     },
     "uid2": {

--- a/package.json
+++ b/package.json
@@ -47,21 +47,21 @@
   "dependencies": {
     "cookie": "^0.3.1",
     "fastify-plugin": "^0.2.1",
-    "fastify-static": "^0.7.0",
-    "h2-auto-push": "^0.2.0"
+    "fastify-static": "^0.8.0",
+    "h2-auto-push": "^0.3.0"
   },
   "devDependencies": {
     "@types/cookie": "^0.3.1",
     "@types/get-port": "^3.2.0",
     "@types/node": "^9.4.0",
     "@types/send": "^0.14.4",
-    "ava": "^0.24.0",
+    "ava": "^0.25.0",
     "codecov": "^3.0.0",
     "fastify": "^0.43.0",
     "get-port": "^3.2.0",
     "gts": "^0.5.3",
-    "js-green-licenses": "^0.3.1",
+    "js-green-licenses": "^0.4.0",
     "nyc": "^11.4.1",
-    "typescript": "~2.6.2"
+    "typescript": "~2.7.1"
   }
 }

--- a/samples/static-page/package-lock.json
+++ b/samples/static-page/package-lock.json
@@ -4,17 +4,23 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw=="
+    },
     "@types/node": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.9.tgz",
-      "integrity": "sha512-s+c3AjymyAccTI4hcgNFK4mToH8l+hyPDhu4LIkn71lRy56FLijGu00fyLgldjM/846Pmk9N4KFUs2P8GDs0pA=="
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.1.tgz",
+      "integrity": "sha512-9ESUxmXt1Isc1xKfDBZ7tpULyTPY5ZCywcfvQTXoLUqP+n4D+MBH+0n75hdzrcmfCc3eWByOi27+GLmMuAvcUA=="
     },
     "@types/pino": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-4.7.0.tgz",
-      "integrity": "sha512-aPHbxwzPb6xjT6nXEQevAZPvxM7niraWxFcxxk15ZMXJkYZVaQbTePMP/Yucu1diQADfGQJEGxhVvTxESQFCfA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-4.7.1.tgz",
+      "integrity": "sha512-jatsMBAonuhTB1NhJsbDjvw7p71q3AvHii276OifMQ1RAE9NaX1EEmcG1lxONA1bQIYKjJbTJIj5UHicnYYDPA==",
       "requires": {
-        "@types/node": "8.5.9"
+        "@types/events": "1.1.0",
+        "@types/node": "9.4.1"
       }
     },
     "abstract-logging": {
@@ -23,9 +29,9 @@
       "integrity": "sha1-i33q/TEFWbwo93ck3RuzAXcnjBs="
     },
     "ajv": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.0.1.tgz",
-      "integrity": "sha1-KJhYCp8971+chd/q16IiPvE889o=",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",
+      "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
       "requires": {
         "fast-deep-equal": "1.0.0",
         "fast-json-stable-stringify": "2.0.0",
@@ -49,18 +55,13 @@
       }
     },
     "avvio": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/avvio/-/avvio-4.0.1.tgz",
-      "integrity": "sha512-Vaga4uQkddyK3OQydLmOb4FubSxsZ7rmXX+n+JwBNEriidXNixAPVEClHEQp70xXSoY/JOLlGDM3gtRkvTcc6A==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-5.3.0.tgz",
+      "integrity": "sha512-4LDQxckZh+9Z8DNeSpRr5uzx4Y12kOFwXgDfgoFq93vk9e8gcnYIYq2LoeXCRTJn2KRFX5t7oIbUzYdbVqf9ag==",
       "requires": {
         "debug": "3.1.0",
         "fastq": "1.5.0"
       }
-    },
-    "bloomfilter": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/bloomfilter/-/bloomfilter-0.0.16.tgz",
-      "integrity": "sha1-QmAjkMdGa905BISUeC0+GmoPKvM="
     },
     "chalk": {
       "version": "2.3.0",
@@ -84,11 +85,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -151,14 +147,6 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
-    "fast-iterator": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fast-iterator/-/fast-iterator-0.2.1.tgz",
-      "integrity": "sha512-APmMxsY5Lo7LHmuULf9xbnKbwFkAQPUOo2+eo9NnnmR3PnLqe4IIMlHevqwl6PdahTE/Uv16U2s5ffsC7Ys3jA==",
-      "requires": {
-        "reusify": "1.0.3"
-      }
-    },
     "fast-json-parse": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
@@ -170,12 +158,11 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-json-stringify": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-0.17.0.tgz",
-      "integrity": "sha512-u6d857jtxcTTm00UIFDO6jCB3R/c0AzH89AxU3rI1twmkVPAHo/riUGH20UaDOMem9YXwcKrnoX6pF2dG3xlHA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-1.0.0.tgz",
+      "integrity": "sha512-4qpMIL388PITAQszTIURR77ygCvyP7P+ZP5ngeBYFVBPWAtU/o9HXGaZgbrN6FiBZzhc+WNr47YYWa7MqhXk5A==",
       "requires": {
-        "ajv": "6.0.1",
-        "fast-safe-stringify": "1.2.3"
+        "ajv": "6.1.1"
       }
     },
     "fast-safe-stringify": {
@@ -184,35 +171,5940 @@
       "integrity": "sha512-QJYT/i0QYoiZBQ71ivxdyTqkwKkQ0oxACXHYxH2zYHJEgzi2LsbjgvtzTbLi1SZcF190Db2YP7I7eTsU2egOlw=="
     },
     "fastify": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-0.39.1.tgz",
-      "integrity": "sha512-bOf1MPzXWLZpwS3l9vJQzW8G/PdMljRTKJsAMg3ykudknkQ0HXFI+h+L9g4XCjlLsqGNvFXBZ2VwXkYF/SsOgg==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-0.43.0.tgz",
+      "integrity": "sha512-jlVWFTOaeIwDs48GE6t0XmWJuCGPtF/OG/QsygzbRZOeVZKjzMw5SYTPouRBgcodXIAFt1vKZ0Iq7oF8/jwC1Q==",
       "requires": {
-        "@types/node": "8.5.9",
-        "@types/pino": "4.7.0",
+        "@types/pino": "4.7.1",
         "abstract-logging": "1.0.0",
-        "ajv": "6.0.1",
-        "avvio": "4.0.1",
-        "fast-iterator": "0.2.1",
-        "fast-json-stringify": "0.17.0",
-        "find-my-way": "1.9.0",
+        "ajv": "6.1.1",
+        "avvio": "5.3.0",
+        "end-of-stream": "1.4.1",
+        "fast-json-stringify": "1.0.0",
+        "find-my-way": "1.10.1",
         "flatstr": "1.0.5",
         "light-my-request": "2.0.1",
-        "middie": "3.0.0",
-        "pino": "4.10.3",
-        "pump": "2.0.0"
+        "middie": "3.1.0",
+        "pino": "4.10.4"
       }
     },
     "fastify-auto-push": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/fastify-auto-push/-/fastify-auto-push-0.2.0.tgz",
-      "integrity": "sha512-0sSe5grVgPlFZDPm1GVR1xAaxZmwmySAQmJB3xLbhyAw0xkZDXpEausprafpeBJJITWwwEAY5OsycyC2H3e6Mg==",
+      "version": "file:../..",
       "requires": {
         "cookie": "0.3.1",
-        "fastify": "0.39.1",
         "fastify-plugin": "0.2.1",
-        "h2-auto-push": "0.2.0",
-        "send": "0.16.1"
+        "fastify-static": "0.8.0",
+        "h2-auto-push": "0.3.0"
+      },
+      "dependencies": {
+        "@ava/babel-plugin-throws-helper": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "@ava/babel-preset-stage-4": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-check-es2015-constants": "6.22.0",
+            "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+            "babel-plugin-transform-async-to-generator": "6.24.1",
+            "babel-plugin-transform-es2015-destructuring": "6.23.0",
+            "babel-plugin-transform-es2015-function-name": "6.24.1",
+            "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+            "babel-plugin-transform-es2015-parameters": "6.24.1",
+            "babel-plugin-transform-es2015-spread": "6.22.0",
+            "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+            "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+            "babel-plugin-transform-exponentiation-operator": "6.24.1",
+            "package-hash": "1.2.0"
+          },
+          "dependencies": {
+            "md5-hex": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "md5-o-matic": "0.1.1"
+              }
+            },
+            "package-hash": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "md5-hex": "1.3.0"
+              }
+            }
+          }
+        },
+        "@ava/babel-preset-transform-test-files": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "@ava/babel-plugin-throws-helper": "2.0.0",
+            "babel-plugin-espower": "2.4.0"
+          }
+        },
+        "@ava/write-file-atomic": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
+        },
+        "@concordance/react": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "arrify": "1.0.1"
+          }
+        },
+        "@ladjs/time-require": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "chalk": "0.4.0",
+            "date-time": "0.1.1",
+            "pretty-ms": "0.2.2",
+            "text-table": "0.2.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "0.4.0",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "1.0.0",
+                "has-color": "0.1.7",
+                "strip-ansi": "0.1.1"
+              }
+            },
+            "date-time": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "parse-ms": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "pretty-ms": {
+              "version": "0.2.2",
+              "bundled": true,
+              "requires": {
+                "parse-ms": "0.1.2"
+              }
+            },
+            "strip-ansi": {
+              "version": "0.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "@types/cookie": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "@types/events": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "@types/get-port": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "@types/mime": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "@types/node": {
+          "version": "9.4.1",
+          "bundled": true
+        },
+        "@types/pino": {
+          "version": "4.7.1",
+          "bundled": true,
+          "requires": {
+            "@types/events": "1.1.0",
+            "@types/node": "9.4.1"
+          }
+        },
+        "@types/send": {
+          "version": "0.14.4",
+          "bundled": true,
+          "requires": {
+            "@types/mime": "2.0.0",
+            "@types/node": "9.4.1"
+          }
+        },
+        "abstract-logging": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-align": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "2.1.1"
+          }
+        },
+        "ansi-escapes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "bundled": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "anymatch": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "micromatch": "2.3.11",
+            "normalize-path": "2.1.1"
+          }
+        },
+        "argparse": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "sprintf-js": "1.0.3"
+          }
+        },
+        "argv": {
+          "version": "0.0.2",
+          "bundled": true
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "arr-exclude": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "array-differ": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "array-find-index": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "array-uniq": "1.0.3"
+          }
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true
+        },
+        "async-each": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "auto-bind": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "ava": {
+          "version": "0.25.0",
+          "bundled": true,
+          "requires": {
+            "@ava/babel-preset-stage-4": "1.1.0",
+            "@ava/babel-preset-transform-test-files": "3.0.0",
+            "@ava/write-file-atomic": "2.2.0",
+            "@concordance/react": "1.0.0",
+            "@ladjs/time-require": "0.1.4",
+            "ansi-escapes": "3.0.0",
+            "ansi-styles": "3.2.0",
+            "arr-flatten": "1.1.0",
+            "array-union": "1.0.2",
+            "array-uniq": "1.0.3",
+            "arrify": "1.0.1",
+            "auto-bind": "1.1.0",
+            "ava-init": "0.2.1",
+            "babel-core": "6.26.0",
+            "babel-generator": "6.26.0",
+            "babel-plugin-syntax-object-rest-spread": "6.13.0",
+            "bluebird": "3.5.1",
+            "caching-transform": "1.0.1",
+            "chalk": "2.3.0",
+            "chokidar": "1.7.0",
+            "clean-stack": "1.3.0",
+            "clean-yaml-object": "0.1.0",
+            "cli-cursor": "2.1.0",
+            "cli-spinners": "1.1.0",
+            "cli-truncate": "1.1.0",
+            "co-with-promise": "4.6.0",
+            "code-excerpt": "2.1.1",
+            "common-path-prefix": "1.0.0",
+            "concordance": "3.0.0",
+            "convert-source-map": "1.5.1",
+            "core-assert": "0.2.1",
+            "currently-unhandled": "0.4.1",
+            "debug": "3.1.0",
+            "dot-prop": "4.2.0",
+            "empower-core": "0.6.2",
+            "equal-length": "1.0.1",
+            "figures": "2.0.0",
+            "find-cache-dir": "1.0.0",
+            "fn-name": "2.0.1",
+            "get-port": "3.2.0",
+            "globby": "6.1.0",
+            "has-flag": "2.0.0",
+            "hullabaloo-config-manager": "1.1.1",
+            "ignore-by-default": "1.0.1",
+            "import-local": "0.1.1",
+            "indent-string": "3.2.0",
+            "is-ci": "1.1.0",
+            "is-generator-fn": "1.0.0",
+            "is-obj": "1.0.1",
+            "is-observable": "1.1.0",
+            "is-promise": "2.1.0",
+            "last-line-stream": "1.0.0",
+            "lodash.clonedeepwith": "4.5.0",
+            "lodash.debounce": "4.0.8",
+            "lodash.difference": "4.5.0",
+            "lodash.flatten": "4.4.0",
+            "loud-rejection": "1.6.0",
+            "make-dir": "1.1.0",
+            "matcher": "1.0.0",
+            "md5-hex": "2.0.0",
+            "meow": "3.7.0",
+            "ms": "2.0.0",
+            "multimatch": "2.1.0",
+            "observable-to-promise": "0.5.0",
+            "option-chain": "1.0.0",
+            "package-hash": "2.0.0",
+            "pkg-conf": "2.1.0",
+            "plur": "2.1.2",
+            "pretty-ms": "3.1.0",
+            "require-precompiled": "0.1.0",
+            "resolve-cwd": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "semver": "5.4.1",
+            "slash": "1.0.0",
+            "source-map-support": "0.5.1",
+            "stack-utils": "1.0.1",
+            "strip-ansi": "4.0.0",
+            "strip-bom-buf": "1.0.0",
+            "supertap": "1.0.0",
+            "supports-color": "5.1.0",
+            "trim-off-newlines": "1.0.1",
+            "unique-temp-dir": "1.0.0",
+            "update-notifier": "2.3.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "camelcase-keys": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "camelcase": "2.1.1",
+                "map-obj": "1.0.1"
+              }
+            },
+            "code-excerpt": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "convert-to-spaces": "1.0.2"
+              }
+            },
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
+            },
+            "load-json-file": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0"
+              }
+            },
+            "map-obj": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "meow": {
+              "version": "3.7.0",
+              "bundled": true,
+              "requires": {
+                "camelcase-keys": "2.1.0",
+                "decamelize": "1.2.0",
+                "loud-rejection": "1.6.0",
+                "map-obj": "1.0.1",
+                "minimist": "1.2.0",
+                "normalize-package-data": "2.4.0",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "redent": "1.0.0",
+                "trim-newlines": "1.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "1.3.1"
+              }
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "2.0.1"
+              }
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "pinkie": {
+              "version": "2.0.4",
+              "bundled": true
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "pinkie": "2.0.4"
+              }
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "1.1.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "1.1.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
+              }
+            },
+            "redent": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "indent-string": "2.1.0",
+                "strip-indent": "1.0.1"
+              },
+              "dependencies": {
+                "indent-string": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "repeating": "2.0.1"
+                  }
+                }
+              }
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-utf8": "0.2.1"
+              }
+            },
+            "strip-indent": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "get-stdin": "4.0.1"
+              }
+            },
+            "supports-color": {
+              "version": "5.1.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            },
+            "trim-newlines": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "ava-init": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "arr-exclude": "1.0.0",
+            "execa": "0.7.0",
+            "has-yarn": "1.0.0",
+            "read-pkg-up": "2.0.0",
+            "write-pkg": "3.1.0"
+          },
+          "dependencies": {
+            "load-json-file": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "strip-bom": "3.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "1.3.1"
+              }
+            },
+            "path-type": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "pify": "2.3.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "read-pkg": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "2.0.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "2.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "2.1.0",
+                "read-pkg": "2.0.0"
+              }
+            }
+          }
+        },
+        "avvio": {
+          "version": "5.3.0",
+          "bundled": true,
+          "requires": {
+            "debug": "3.1.0",
+            "fastq": "1.5.0"
+          }
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "axios": {
+          "version": "0.17.1",
+          "bundled": true,
+          "requires": {
+            "follow-redirects": "1.3.0",
+            "is-buffer": "1.1.6"
+          }
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-core": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.0",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.1",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.4",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "1.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-helper-builder-binary-assignment-operator-visitor": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-explode-assignable-expression": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-call-delegate": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-hoist-variables": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-explode-assignable-expression": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-function-name": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-get-function-arity": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-get-function-arity": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-hoist-variables": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-regex": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-helper-remap-async-to-generator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helpers": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-check-es2015-constants": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-espower": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "babel-generator": "6.26.0",
+            "babylon": "6.18.0",
+            "call-matcher": "1.0.1",
+            "core-js": "2.5.3",
+            "espower-location-detector": "1.0.0",
+            "espurify": "1.7.0",
+            "estraverse": "4.2.0"
+          }
+        },
+        "babel-plugin-syntax-async-functions": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-exponentiation-operator": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-object-rest-spread": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-trailing-function-commas": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-async-to-generator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-remap-async-to-generator": "6.24.1",
+            "babel-plugin-syntax-async-functions": "6.13.0",
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-strict-mode": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-call-delegate": "6.24.1",
+            "babel-helper-get-function-arity": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "regexpu-core": "2.0.0"
+          }
+        },
+        "babel-plugin-transform-exponentiation-operator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+            "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-strict-mode": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-register": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-core": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "core-js": "2.5.3",
+            "home-or-tmp": "2.0.0",
+            "lodash": "4.17.4",
+            "mkdirp": "0.5.1",
+            "source-map-support": "0.4.18"
+          },
+          "dependencies": {
+            "source-map-support": {
+              "version": "0.4.18",
+              "bundled": true,
+              "requires": {
+                "source-map": "0.5.7"
+              }
+            }
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "binary-extensions": {
+          "version": "1.11.0",
+          "bundled": true
+        },
+        "bloomfilter": {
+          "version": "0.0.16",
+          "bundled": true
+        },
+        "bluebird": {
+          "version": "3.5.1",
+          "bundled": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "boxen": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "ansi-align": "2.0.0",
+            "camelcase": "4.1.0",
+            "chalk": "2.3.0",
+            "cli-boxes": "1.0.0",
+            "string-width": "2.1.1",
+            "term-size": "1.2.0",
+            "widest-line": "1.0.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "1.8.5",
+          "bundled": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "buf-compare": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "builtins": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "caching-transform": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.3.4"
+          },
+          "dependencies": {
+            "md5-hex": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "md5-o-matic": "0.1.1"
+              }
+            },
+            "write-file-atomic": {
+              "version": "1.3.4",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "imurmurhash": "0.1.4",
+                "slide": "1.1.6"
+              }
+            }
+          }
+        },
+        "call-matcher": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "core-js": "2.5.3",
+            "deep-equal": "1.0.1",
+            "espurify": "1.7.0",
+            "estraverse": "4.2.0"
+          }
+        },
+        "call-signature": {
+          "version": "0.0.2",
+          "bundled": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
+          }
+        },
+        "capture-stack-trace": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "chokidar": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "anymatch": "1.3.2",
+            "async-each": "1.0.1",
+            "fsevents": "1.1.3",
+            "glob-parent": "2.0.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "2.0.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0"
+          }
+        },
+        "ci-info": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "clang-format": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "async": "1.5.2",
+            "glob": "7.1.2",
+            "resolve": "1.5.0"
+          }
+        },
+        "clean-stack": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "clean-yaml-object": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "cli-boxes": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "restore-cursor": "2.0.0"
+          }
+        },
+        "cli-spinners": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "cli-truncate": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "slice-ansi": "1.0.0",
+            "string-width": "2.1.1"
+          }
+        },
+        "cli-width": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "co-with-promise": {
+          "version": "4.6.0",
+          "bundled": true,
+          "requires": {
+            "pinkie-promise": "1.0.0"
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "codecov": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "argv": "0.0.2",
+            "request": "2.81.0",
+            "urlgrey": "0.4.4"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.0",
+          "bundled": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "bundled": true
+        },
+        "common-path-prefix": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "concordance": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "date-time": "2.1.0",
+            "esutils": "2.0.2",
+            "fast-diff": "1.1.2",
+            "function-name-support": "0.2.0",
+            "js-string-escape": "1.0.1",
+            "lodash.clonedeep": "4.5.0",
+            "lodash.flattendeep": "4.4.0",
+            "lodash.merge": "4.6.0",
+            "md5-hex": "2.0.0",
+            "semver": "5.4.1",
+            "well-known-symbols": "1.0.0"
+          }
+        },
+        "configstore": {
+          "version": "3.1.1",
+          "bundled": true,
+          "requires": {
+            "dot-prop": "4.2.0",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.1.0",
+            "unique-string": "1.0.0",
+            "write-file-atomic": "2.3.0",
+            "xdg-basedir": "3.0.0"
+          }
+        },
+        "convert-source-map": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "convert-to-spaces": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "core-assert": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "buf-compare": "1.0.1",
+            "is-error": "2.2.1"
+          }
+        },
+        "core-js": {
+          "version": "2.5.3",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "create-error-class": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "capture-stack-trace": "1.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "crypto-random-string": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "currently-unhandled": {
+          "version": "0.4.1",
+          "bundled": true,
+          "requires": {
+            "array-find-index": "1.0.2"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "date-time": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "time-zone": "1.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "decamelize-keys": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "decamelize": "1.2.0",
+            "map-obj": "1.0.1"
+          },
+          "dependencies": {
+            "map-obj": {
+              "version": "1.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "depd": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "destroy": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
+        },
+        "diff": {
+          "version": "3.4.0",
+          "bundled": true
+        },
+        "dot-prop": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "is-obj": "1.0.1"
+          }
+        },
+        "duplexer3": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "ee-first": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "empower-core": {
+          "version": "0.6.2",
+          "bundled": true,
+          "requires": {
+            "call-signature": "0.0.2",
+            "core-js": "2.5.3"
+          }
+        },
+        "encodeurl": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0"
+          }
+        },
+        "equal-length": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "es6-error": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "espower-location-detector": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-url": "1.2.2",
+            "path-is-absolute": "1.0.1",
+            "source-map": "0.5.7",
+            "xtend": "4.0.1"
+          }
+        },
+        "esprima": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "espurify": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "2.5.3"
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "etag": {
+          "version": "1.8.1",
+          "bundled": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true,
+          "requires": {
+            "fill-range": "2.2.3"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "external-editor": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "chardet": "0.4.2",
+            "iconv-lite": "0.4.19",
+            "tmp": "0.0.33"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fast-diff": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "fast-json-parse": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fast-json-stringify": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "ajv": "6.1.1"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "6.1.1",
+              "bundled": true,
+              "requires": {
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+              }
+            }
+          }
+        },
+        "fast-safe-stringify": {
+          "version": "1.2.3",
+          "bundled": true
+        },
+        "fastify": {
+          "version": "0.43.0",
+          "bundled": true,
+          "requires": {
+            "@types/pino": "4.7.1",
+            "abstract-logging": "1.0.0",
+            "ajv": "6.1.1",
+            "avvio": "5.3.0",
+            "end-of-stream": "1.4.1",
+            "fast-json-stringify": "1.0.0",
+            "find-my-way": "1.10.1",
+            "flatstr": "1.0.5",
+            "light-my-request": "2.0.1",
+            "middie": "3.1.0",
+            "pino": "4.10.4"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "6.1.1",
+              "bundled": true,
+              "requires": {
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+              }
+            }
+          }
+        },
+        "fastify-plugin": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "semver": "5.4.1"
+          }
+        },
+        "fastify-static": {
+          "version": "0.8.0",
+          "bundled": true,
+          "requires": {
+            "fastify-plugin": "0.2.1",
+            "send": "0.16.1"
+          }
+        },
+        "fastq": {
+          "version": "1.5.0",
+          "bundled": true,
+          "requires": {
+            "reusify": "1.0.4"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5"
+          }
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "fill-range": {
+          "version": "2.2.3",
+          "bundled": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.7",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "find-cache-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "make-dir": "1.1.0",
+            "pkg-dir": "2.0.0"
+          }
+        },
+        "find-my-way": {
+          "version": "1.10.1",
+          "bundled": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "flatstr": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "fn-name": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "follow-redirects": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "debug": "3.1.0"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fsevents": {
+          "version": "1.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "nan": "2.8.0",
+            "node-pre-gyp": "0.6.39"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "ajv": {
+              "version": "4.11.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
+              }
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "aproba": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.2.9"
+              }
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "bundled": true,
+              "optional": true
+            },
+            "assert-plus": {
+              "version": "0.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "bundled": true,
+              "optional": true
+            },
+            "aws-sign2": {
+              "version": "0.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "balanced-match": {
+              "version": "0.4.2",
+              "bundled": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "block-stream": {
+              "version": "0.0.9",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3"
+              }
+            },
+            "boom": {
+              "version": "2.10.1",
+              "bundled": true,
+              "requires": {
+                "hoek": "2.16.3"
+              }
+            },
+            "brace-expansion": {
+              "version": "1.1.7",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "0.4.2",
+                "concat-map": "0.0.1"
+              }
+            },
+            "buffer-shims": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true,
+              "optional": true
+            },
+            "co": {
+              "version": "4.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "cryptiles": {
+              "version": "2.0.5",
+              "bundled": true,
+              "requires": {
+                "boom": "2.10.1"
+              }
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "debug": {
+              "version": "2.6.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.4.2",
+              "bundled": true,
+              "optional": true
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "extsprintf": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true,
+              "optional": true
+            },
+            "form-data": {
+              "version": "2.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.15"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "fstream": {
+              "version": "1.0.11",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1"
+              }
+            },
+            "fstream-ignore": {
+              "version": "1.0.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "fstream": "1.0.11",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4"
+              }
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aproba": "1.1.1",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
+              }
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "bundled": true
+            },
+            "har-schema": {
+              "version": "1.0.5",
+              "bundled": true,
+              "optional": true
+            },
+            "har-validator": {
+              "version": "4.2.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ajv": "4.11.8",
+                "har-schema": "1.0.5"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "bundled": true,
+              "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+              }
+            },
+            "hoek": {
+              "version": "2.16.3",
+              "bundled": true
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.0",
+                "sshpk": "1.13.0"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.4",
+              "bundled": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "jodid25519": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "bundled": true,
+              "optional": true
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsonify": "0.0.0"
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "jsprim": {
+              "version": "1.4.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.0.2",
+                "json-schema": "0.2.3",
+                "verror": "1.3.6"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "mime-db": {
+              "version": "1.27.0",
+              "bundled": true
+            },
+            "mime-types": {
+              "version": "2.1.15",
+              "bundled": true,
+              "requires": {
+                "mime-db": "1.27.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "node-pre-gyp": {
+              "version": "0.6.39",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "1.0.2",
+                "hawk": "3.1.3",
+                "mkdirp": "0.5.1",
+                "nopt": "4.0.1",
+                "npmlog": "4.1.0",
+                "rc": "1.2.1",
+                "request": "2.81.0",
+                "rimraf": "2.6.1",
+                "semver": "5.3.0",
+                "tar": "2.2.1",
+                "tar-pack": "3.4.0"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1.1.0",
+                "osenv": "0.1.4"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "performance-now": {
+              "version": "0.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "bundled": true
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true,
+              "optional": true
+            },
+            "qs": {
+              "version": "6.4.0",
+              "bundled": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "0.4.2",
+                "ini": "1.3.4",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.2.9",
+              "bundled": true,
+              "requires": {
+                "buffer-shims": "1.0.0",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "1.0.1",
+                "util-deprecate": "1.0.2"
+              }
+            },
+            "request": {
+              "version": "2.81.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.15",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.0.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.1",
+              "bundled": true,
+              "requires": {
+                "glob": "7.1.2"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "semver": {
+              "version": "5.3.0",
+              "bundled": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "sntp": {
+              "version": "1.0.9",
+              "bundled": true,
+              "requires": {
+                "hoek": "2.16.3"
+              }
+            },
+            "sshpk": {
+              "version": "1.13.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jodid25519": "1.0.2",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.0.1"
+              }
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true,
+              "optional": true
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+              }
+            },
+            "tar-pack": {
+              "version": "3.4.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "debug": "2.6.8",
+                "fstream": "1.0.11",
+                "fstream-ignore": "1.0.5",
+                "once": "1.4.0",
+                "readable-stream": "2.2.9",
+                "rimraf": "2.6.1",
+                "tar": "2.2.1",
+                "uid-number": "0.0.6"
+              }
+            },
+            "tough-cookie": {
+              "version": "2.3.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "punycode": "1.4.1"
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "5.0.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "bundled": true,
+              "optional": true
+            },
+            "uid-number": {
+              "version": "0.0.6",
+              "bundled": true,
+              "optional": true
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "uuid": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "verror": {
+              "version": "1.3.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "extsprintf": "1.0.2"
+              }
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "string-width": "1.0.2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "function-name-support": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "get-port": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
+        "global-dirs": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "ini": "1.3.4"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true
+        },
+        "globby": {
+          "version": "6.1.0",
+          "bundled": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "pinkie": {
+              "version": "2.0.4",
+              "bundled": true
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "pinkie": "2.0.4"
+              }
+            }
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "bundled": true,
+          "requires": {
+            "create-error-class": "3.0.2",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.0",
+            "safe-buffer": "5.1.1",
+            "timed-out": "4.0.1",
+            "unzip-response": "2.0.1",
+            "url-parse-lax": "1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "gts": {
+          "version": "0.5.3",
+          "bundled": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "clang-format": "1.2.1",
+            "inquirer": "3.3.0",
+            "meow": "4.0.0",
+            "pify": "3.0.0",
+            "rimraf": "2.6.2",
+            "tslint": "5.8.0",
+            "update-notifier": "2.3.0",
+            "write-file-atomic": "2.3.0"
+          }
+        },
+        "h2-auto-push": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "bloomfilter": "0.0.16"
+          }
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "has-color": {
+          "version": "0.1.7",
+          "bundled": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "has-yarn": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true
+        },
+        "home-or-tmp": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.5.0",
+          "bundled": true
+        },
+        "http-errors": {
+          "version": "1.6.2",
+          "bundled": true,
+          "requires": {
+            "depd": "1.1.1",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.3",
+            "statuses": "1.3.1"
+          }
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "hullabaloo-config-manager": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "dot-prop": "4.2.0",
+            "es6-error": "4.1.1",
+            "graceful-fs": "4.1.11",
+            "indent-string": "3.2.0",
+            "json5": "0.5.1",
+            "lodash.clonedeep": "4.5.0",
+            "lodash.clonedeepwith": "4.5.0",
+            "lodash.isequal": "4.5.0",
+            "lodash.merge": "4.6.0",
+            "md5-hex": "2.0.0",
+            "package-hash": "2.0.0",
+            "pkg-dir": "2.0.0",
+            "resolve-from": "3.0.0",
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "bundled": true
+        },
+        "ignore-by-default": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "import-lazy": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "import-local": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "pkg-dir": "2.0.0",
+            "resolve-cwd": "2.0.0"
+          }
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "ansi-escapes": "3.0.0",
+            "chalk": "2.3.0",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "2.1.0",
+            "figures": "2.0.0",
+            "lodash": "4.17.4",
+            "mute-stream": "0.0.7",
+            "run-async": "2.3.0",
+            "rx-lite": "4.0.8",
+            "rx-lite-aggregates": "4.0.8",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
+          }
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "irregular-plurals": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "binary-extensions": "1.11.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-ci": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ci-info": "1.1.2"
+          }
+        },
+        "is-dotfile": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true,
+          "requires": {
+            "is-primitive": "2.0.0"
+          }
+        },
+        "is-error": {
+          "version": "2.2.1",
+          "bundled": true
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-generator-fn": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "is-installed-globally": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "global-dirs": "0.1.0",
+            "is-path-inside": "1.0.0"
+          }
+        },
+        "is-npm": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-obj": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-observable": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "symbol-observable": "1.1.0"
+          }
+        },
+        "is-path-inside": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "path-is-inside": "1.0.2"
+          }
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-promise": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-redirect": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-retry-allowed": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-url": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "js-green-licenses": {
+          "version": "0.4.0",
+          "bundled": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "axios": "0.17.1",
+            "npm-package-arg": "6.0.0",
+            "package-json": "4.0.1",
+            "pify": "3.0.0",
+            "spdx-correct": "2.0.4",
+            "spdx-satisfies": "0.1.3",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "spdx-correct": {
+              "version": "2.0.4",
+              "bundled": true,
+              "requires": {
+                "spdx-expression-parse": "2.0.2",
+                "spdx-license-ids": "2.0.1"
+              }
+            },
+            "spdx-expression-parse": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "spdx-exceptions": "2.1.0",
+                "spdx-license-ids": "2.0.1"
+              }
+            },
+            "spdx-license-ids": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "js-string-escape": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "bundled": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsesc": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "json5": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "last-line-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "through2": "2.0.3"
+          }
+        },
+        "latest-version": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "package-json": "4.0.1"
+          }
+        },
+        "light-my-request": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "ajv": "6.1.1",
+            "readable-stream": "2.3.3",
+            "safe-buffer": "5.1.1"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "6.1.1",
+              "bundled": true,
+              "requires": {
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+              }
+            }
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "bundled": true
+        },
+        "lodash.clonedeep": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.clonedeepwith": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.debounce": {
+          "version": "4.0.8",
+          "bundled": true
+        },
+        "lodash.difference": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.flatten": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lodash.flattendeep": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lodash.isequal": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.merge": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "loud-rejection": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "currently-unhandled": "0.4.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "lowercase-keys": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "4.1.1",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "pify": "3.0.0"
+          }
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "matcher": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5"
+          }
+        },
+        "md5-hex": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "meow": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        },
+        "middie": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "path-to-regexp": "2.1.0",
+            "reusify": "1.0.4"
+          }
+        },
+        "mime-db": {
+          "version": "1.30.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.30.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "minimist-options": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "is-plain-obj": "1.1.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "multimatch": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "array-differ": "1.0.0",
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "minimatch": "3.0.4"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "nan": {
+          "version": "2.8.0",
+          "bundled": true,
+          "optional": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.4.1",
+            "validate-npm-package-license": "3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "remove-trailing-separator": "1.1.0"
+          }
+        },
+        "npm-package-arg": {
+          "version": "6.0.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "osenv": "0.1.4",
+            "semver": "5.4.1",
+            "validate-npm-package-name": "3.0.0"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "nyc": {
+          "version": "11.4.1",
+          "bundled": true,
+          "requires": {
+            "archy": "1.0.0",
+            "arrify": "1.0.1",
+            "caching-transform": "1.0.1",
+            "convert-source-map": "1.5.1",
+            "debug-log": "1.0.1",
+            "default-require-extensions": "1.0.0",
+            "find-cache-dir": "0.1.1",
+            "find-up": "2.1.0",
+            "foreground-child": "1.5.6",
+            "glob": "7.1.2",
+            "istanbul-lib-coverage": "1.1.1",
+            "istanbul-lib-hook": "1.1.0",
+            "istanbul-lib-instrument": "1.9.1",
+            "istanbul-lib-report": "1.1.2",
+            "istanbul-lib-source-maps": "1.2.2",
+            "istanbul-reports": "1.1.3",
+            "md5-hex": "1.3.0",
+            "merge-source-map": "1.0.4",
+            "micromatch": "2.3.11",
+            "mkdirp": "0.5.1",
+            "resolve-from": "2.0.0",
+            "rimraf": "2.6.2",
+            "signal-exit": "3.0.2",
+            "spawn-wrap": "1.4.2",
+            "test-exclude": "4.1.1",
+            "yargs": "10.0.3",
+            "yargs-parser": "8.0.0"
+          },
+          "dependencies": {
+            "align-text": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
+              }
+            },
+            "amdefine": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "append-transform": {
+              "version": "0.4.0",
+              "bundled": true,
+              "requires": {
+                "default-require-extensions": "1.0.0"
+              }
+            },
+            "archy": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "1.1.0"
+              }
+            },
+            "arr-flatten": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "arrify": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "async": {
+              "version": "1.5.2",
+              "bundled": true
+            },
+            "babel-code-frame": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
+              }
+            },
+            "babel-generator": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "detect-indent": "4.0.0",
+                "jsesc": "1.3.0",
+                "lodash": "4.17.4",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
+              }
+            },
+            "babel-messages": {
+              "version": "6.23.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0"
+              }
+            },
+            "babel-runtime": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "core-js": "2.5.3",
+                "regenerator-runtime": "0.11.1"
+              }
+            },
+            "babel-template": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "lodash": "4.17.4"
+              }
+            },
+            "babel-traverse": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-code-frame": "6.26.0",
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "debug": "2.6.9",
+                "globals": "9.18.0",
+                "invariant": "2.2.2",
+                "lodash": "4.17.4"
+              }
+            },
+            "babel-types": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "esutils": "2.0.2",
+                "lodash": "4.17.4",
+                "to-fast-properties": "1.0.3"
+              }
+            },
+            "babylon": {
+              "version": "6.18.0",
+              "bundled": true
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.8",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+              }
+            },
+            "builtin-modules": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "caching-transform": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "md5-hex": "1.3.0",
+                "mkdirp": "0.5.1",
+                "write-file-atomic": "1.3.4"
+              }
+            },
+            "camelcase": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true
+            },
+            "center-align": {
+              "version": "0.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
+              }
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              }
+            },
+            "cliui": {
+              "version": "2.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "center-align": "0.1.3",
+                "right-align": "0.1.3",
+                "wordwrap": "0.0.2"
+              },
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "commondir": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "convert-source-map": {
+              "version": "1.5.1",
+              "bundled": true
+            },
+            "core-js": {
+              "version": "2.5.3",
+              "bundled": true
+            },
+            "cross-spawn": {
+              "version": "4.0.2",
+              "bundled": true,
+              "requires": {
+                "lru-cache": "4.1.1",
+                "which": "1.3.0"
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "debug-log": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "decamelize": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "default-require-extensions": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "strip-bom": "2.0.0"
+              }
+            },
+            "detect-indent": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "repeating": "2.0.1"
+              }
+            },
+            "error-ex": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "is-arrayish": "0.2.1"
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true
+            },
+            "execa": {
+              "version": "0.7.0",
+              "bundled": true,
+              "requires": {
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+              },
+              "dependencies": {
+                "cross-spawn": {
+                  "version": "5.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "lru-cache": "4.1.1",
+                    "shebang-command": "1.2.0",
+                    "which": "1.3.0"
+                  }
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "0.1.1"
+              }
+            },
+            "expand-range": {
+              "version": "1.8.2",
+              "bundled": true,
+              "requires": {
+                "fill-range": "2.2.3"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            },
+            "filename-regex": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "fill-range": {
+              "version": "2.2.3",
+              "bundled": true,
+              "requires": {
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "1.1.7",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
+              }
+            },
+            "find-cache-dir": {
+              "version": "0.1.1",
+              "bundled": true,
+              "requires": {
+                "commondir": "1.0.1",
+                "mkdirp": "0.5.1",
+                "pkg-dir": "1.0.0"
+              }
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "2.0.0"
+              }
+            },
+            "for-in": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "for-own": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "for-in": "1.0.2"
+              }
+            },
+            "foreground-child": {
+              "version": "1.5.6",
+              "bundled": true,
+              "requires": {
+                "cross-spawn": "4.0.2",
+                "signal-exit": "3.0.2"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "get-caller-file": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "glob-base": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
+              }
+            },
+            "glob-parent": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-glob": "2.0.1"
+              }
+            },
+            "globals": {
+              "version": "9.18.0",
+              "bundled": true
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "bundled": true
+            },
+            "handlebars": {
+              "version": "4.0.11",
+              "bundled": true,
+              "requires": {
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.8.29"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.4.4",
+                  "bundled": true,
+                  "requires": {
+                    "amdefine": "1.0.1"
+                  }
+                }
+              }
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "hosted-git-info": {
+              "version": "2.5.0",
+              "bundled": true
+            },
+            "imurmurhash": {
+              "version": "0.1.4",
+              "bundled": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "invariant": {
+              "version": "2.2.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "1.3.1"
+              }
+            },
+            "invert-kv": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-arrayish": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "is-buffer": {
+              "version": "1.1.6",
+              "bundled": true
+            },
+            "is-builtin-module": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "builtin-modules": "1.1.1"
+              }
+            },
+            "is-dotfile": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "is-equal-shallow": {
+              "version": "0.1.3",
+              "bundled": true,
+              "requires": {
+                "is-primitive": "2.0.0"
+              }
+            },
+            "is-extendable": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-finite": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            },
+            "is-number": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            },
+            "is-posix-bracket": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "is-primitive": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-utf8": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "isobject": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            },
+            "istanbul-lib-coverage": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "istanbul-lib-hook": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "append-transform": "0.4.0"
+              }
+            },
+            "istanbul-lib-instrument": {
+              "version": "1.9.1",
+              "bundled": true,
+              "requires": {
+                "babel-generator": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "istanbul-lib-coverage": "1.1.1",
+                "semver": "5.4.1"
+              }
+            },
+            "istanbul-lib-report": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "istanbul-lib-coverage": "1.1.1",
+                "mkdirp": "0.5.1",
+                "path-parse": "1.0.5",
+                "supports-color": "3.2.3"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "3.2.3",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "1.0.0"
+                  }
+                }
+              }
+            },
+            "istanbul-lib-source-maps": {
+              "version": "1.2.2",
+              "bundled": true,
+              "requires": {
+                "debug": "3.1.0",
+                "istanbul-lib-coverage": "1.1.1",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "source-map": "0.5.7"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "3.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                }
+              }
+            },
+            "istanbul-reports": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "handlebars": "4.0.11"
+              }
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "jsesc": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            },
+            "lazy-cache": {
+              "version": "1.0.4",
+              "bundled": true,
+              "optional": true
+            },
+            "lcid": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "invert-kv": "1.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
+              },
+              "dependencies": {
+                "path-exists": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "lodash": {
+              "version": "4.17.4",
+              "bundled": true
+            },
+            "longest": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "3.0.2"
+              }
+            },
+            "lru-cache": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
+              }
+            },
+            "md5-hex": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "md5-o-matic": "0.1.1"
+              }
+            },
+            "md5-o-matic": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "mem": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "mimic-fn": "1.1.0"
+              }
+            },
+            "merge-source-map": {
+              "version": "1.0.4",
+              "bundled": true,
+              "requires": {
+                "source-map": "0.5.7"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
+              }
+            },
+            "mimic-fn": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.8"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "normalize-package-data": {
+              "version": "2.4.0",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "2.5.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.4.1",
+                "validate-npm-package-license": "3.0.1"
+              }
+            },
+            "normalize-path": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "remove-trailing-separator": "1.1.0"
+              }
+            },
+            "npm-run-path": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "path-key": "2.0.1"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "object.omit": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              }
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8",
+                "wordwrap": "0.0.3"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "os-locale": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "execa": "0.7.0",
+                "lcid": "1.0.0",
+                "mem": "1.1.0"
+              }
+            },
+            "p-finally": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "p-limit": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "1.1.0"
+              }
+            },
+            "parse-glob": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+              }
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "1.3.1"
+              }
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "2.0.1"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "path-key": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "path-parse": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "pinkie": {
+              "version": "2.0.4",
+              "bundled": true
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "pinkie": "2.0.4"
+              }
+            },
+            "pkg-dir": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "1.1.2"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "path-exists": "2.1.0",
+                    "pinkie-promise": "2.0.1"
+                  }
+                }
+              }
+            },
+            "preserve": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "pseudomap": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "randomatic": {
+              "version": "1.1.7",
+              "bundled": true,
+              "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+              },
+              "dependencies": {
+                "is-number": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "kind-of": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "1.1.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "1.1.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "path-exists": "2.1.0",
+                    "pinkie-promise": "2.0.1"
+                  }
+                }
+              }
+            },
+            "regenerator-runtime": {
+              "version": "0.11.1",
+              "bundled": true
+            },
+            "regex-cache": {
+              "version": "0.4.4",
+              "bundled": true,
+              "requires": {
+                "is-equal-shallow": "0.1.3"
+              }
+            },
+            "remove-trailing-separator": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "repeat-element": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "repeat-string": {
+              "version": "1.6.1",
+              "bundled": true
+            },
+            "repeating": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-finite": "1.0.2"
+              }
+            },
+            "require-directory": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "require-main-filename": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "resolve-from": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "right-align": {
+              "version": "0.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "align-text": "0.1.4"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "requires": {
+                "glob": "7.1.2"
+              }
+            },
+            "semver": {
+              "version": "5.4.1",
+              "bundled": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "shebang-regex": "1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "slide": {
+              "version": "1.1.6",
+              "bundled": true
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "spawn-wrap": {
+              "version": "1.4.2",
+              "bundled": true,
+              "requires": {
+                "foreground-child": "1.5.6",
+                "mkdirp": "0.5.1",
+                "os-homedir": "1.0.2",
+                "rimraf": "2.6.2",
+                "signal-exit": "3.0.2",
+                "which": "1.3.0"
+              }
+            },
+            "spdx-correct": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "spdx-license-ids": "1.2.2"
+              }
+            },
+            "spdx-expression-parse": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "spdx-license-ids": {
+              "version": "1.2.2",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "3.0.0"
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-utf8": "0.2.1"
+              }
+            },
+            "strip-eof": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "test-exclude": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "arrify": "1.0.1",
+                "micromatch": "2.3.11",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "require-main-filename": "1.0.1"
+              }
+            },
+            "to-fast-properties": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "trim-right": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "source-map": "0.5.7",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+              },
+              "dependencies": {
+                "yargs": {
+                  "version": "3.10.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "camelcase": "1.2.1",
+                    "cliui": "2.1.0",
+                    "decamelize": "1.2.0",
+                    "window-size": "0.1.0"
+                  }
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "spdx-correct": "1.0.2",
+                "spdx-expression-parse": "1.0.4"
+              }
+            },
+            "which": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "isexe": "2.0.0"
+              }
+            },
+            "which-module": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "window-size": {
+              "version": "0.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "bundled": true
+            },
+            "wrap-ansi": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
+              },
+              "dependencies": {
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
+                }
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "write-file-atomic": {
+              "version": "1.3.4",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "imurmurhash": "0.1.4",
+                "slide": "1.1.6"
+              }
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "10.0.3",
+              "bundled": true,
+              "requires": {
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "find-up": "2.1.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "8.0.0"
+              },
+              "dependencies": {
+                "cliui": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wrap-ansi": "2.1.0"
+                  },
+                  "dependencies": {
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "yargs-parser": {
+              "version": "8.0.0",
+              "bundled": true,
+              "requires": {
+                "camelcase": "4.1.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
+          }
+        },
+        "observable-to-promise": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "is-observable": "0.2.0",
+            "symbol-observable": "1.1.0"
+          },
+          "dependencies": {
+            "is-observable": {
+              "version": "0.2.0",
+              "bundled": true,
+              "requires": {
+                "symbol-observable": "0.2.4"
+              },
+              "dependencies": {
+                "symbol-observable": {
+                  "version": "0.2.4",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "1.1.0"
+          }
+        },
+        "option-chain": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "1.1.0"
+          }
+        },
+        "package-hash": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "lodash.flattendeep": "4.4.0",
+            "md5-hex": "2.0.0",
+            "release-zalgo": "1.0.0"
+          }
+        },
+        "package-json": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "got": "6.7.1",
+            "registry-auth-token": "3.3.1",
+            "registry-url": "3.1.0",
+            "semver": "5.4.1"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.3",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
+          }
+        },
+        "parse-ms": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "path-to-regexp": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "pify": "3.0.0"
+          }
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "pinkie": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "pinkie-promise": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "pinkie": "1.0.0"
+          }
+        },
+        "pino": {
+          "version": "4.10.4",
+          "bundled": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "fast-json-parse": "1.0.3",
+            "fast-safe-stringify": "1.2.3",
+            "flatstr": "1.0.5",
+            "pump": "2.0.1",
+            "quick-format-unescaped": "1.1.2",
+            "split2": "2.2.0"
+          }
+        },
+        "pkg-conf": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "load-json-file": "4.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "2.1.0"
+          }
+        },
+        "plur": {
+          "version": "2.1.2",
+          "bundled": true,
+          "requires": {
+            "irregular-plurals": "1.4.0"
+          }
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "pretty-ms": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "parse-ms": "1.0.1",
+            "plur": "2.1.2"
+          }
+        },
+        "private": {
+          "version": "0.1.8",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "pump": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true
+        },
+        "quick-format-unescaped": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "fast-safe-stringify": "1.2.3"
+          }
+        },
+        "quick-lru": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "randomatic": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "rc": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          }
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "readdirp": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "minimatch": "3.0.4",
+            "readable-stream": "2.3.3",
+            "set-immediate-shim": "1.0.1"
+          }
+        },
+        "redent": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
+          }
+        },
+        "regenerate": {
+          "version": "1.3.3",
+          "bundled": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "bundled": true
+        },
+        "regex-cache": {
+          "version": "0.4.4",
+          "bundled": true,
+          "requires": {
+            "is-equal-shallow": "0.1.3"
+          }
+        },
+        "regexpu-core": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "regenerate": "1.3.3",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
+          }
+        },
+        "registry-auth-token": {
+          "version": "3.3.1",
+          "bundled": true,
+          "requires": {
+            "rc": "1.2.2",
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "registry-url": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "rc": "1.2.2"
+          }
+        },
+        "regjsgen": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "jsesc": "0.5.0"
+          }
+        },
+        "release-zalgo": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "es6-error": "4.1.1"
+          }
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
+          }
+        },
+        "require-precompiled": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "resolve": {
+          "version": "1.5.0",
+          "bundled": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          }
+        },
+        "resolve-cwd": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "resolve-from": "3.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "onetime": "2.0.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "reusify": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "is-promise": "2.1.0"
+          }
+        },
+        "rx-lite": {
+          "version": "4.0.8",
+          "bundled": true
+        },
+        "rx-lite-aggregates": {
+          "version": "4.0.8",
+          "bundled": true,
+          "requires": {
+            "rx-lite": "4.0.8"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.4.1",
+          "bundled": true
+        },
+        "semver-diff": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "semver": "5.4.1"
+          }
+        },
+        "send": {
+          "version": "0.16.1",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "1.1.1",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.3.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "mime": {
+              "version": "1.4.1",
+              "bundled": true
+            }
+          }
+        },
+        "serialize-error": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "set-immediate-shim": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "setprototypeof": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0"
+          }
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sort-keys": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-plain-obj": "1.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true
+        },
+        "source-map-support": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "source-map": "0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "spdx-compare": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "spdx-expression-parse": "1.0.4",
+            "spdx-ranges": "1.0.1"
+          }
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "spdx-license-ids": "1.2.2"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "spdx-license-ids": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "spdx-ranges": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "spdx-satisfies": {
+          "version": "0.1.3",
+          "bundled": true,
+          "requires": {
+            "spdx-compare": "0.1.2",
+            "spdx-expression-parse": "1.0.4"
+          }
+        },
+        "split2": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "through2": "2.0.3"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "sshpk": {
+          "version": "1.13.1",
+          "bundled": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "stack-utils": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "strip-bom-buf": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "supertap": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "indent-string": "3.2.0",
+            "js-yaml": "3.10.0",
+            "serialize-error": "2.1.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "symbol-observable": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "term-size": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "execa": "0.7.0"
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "2.3.3",
+            "xtend": "4.0.1"
+          }
+        },
+        "time-zone": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "bundled": true,
+          "requires": {
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "tough-cookie": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "trim-off-newlines": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "tslib": {
+          "version": "1.8.1",
+          "bundled": true
+        },
+        "tslint": {
+          "version": "5.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "builtin-modules": "1.1.1",
+            "chalk": "2.3.0",
+            "commander": "2.12.2",
+            "diff": "3.4.0",
+            "glob": "7.1.2",
+            "minimatch": "3.0.4",
+            "resolve": "1.5.0",
+            "semver": "5.4.1",
+            "tslib": "1.8.1",
+            "tsutils": "2.13.1"
+          }
+        },
+        "tsutils": {
+          "version": "2.13.1",
+          "bundled": true,
+          "requires": {
+            "tslib": "1.8.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "typescript": {
+          "version": "2.7.1",
+          "bundled": true
+        },
+        "uid2": {
+          "version": "0.0.3",
+          "bundled": true
+        },
+        "unique-string": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "crypto-random-string": "1.0.0"
+          }
+        },
+        "unique-temp-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "os-tmpdir": "1.0.2",
+            "uid2": "0.0.3"
+          }
+        },
+        "unzip-response": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "update-notifier": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "boxen": "1.2.2",
+            "chalk": "2.3.0",
+            "configstore": "3.1.1",
+            "import-lazy": "2.1.0",
+            "is-installed-globally": "0.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
+          }
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "prepend-http": "1.0.4"
+          }
+        },
+        "urlgrey": {
+          "version": "0.4.4",
+          "bundled": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          }
+        },
+        "validate-npm-package-name": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "builtins": "1.0.3"
+          }
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "1.3.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "well-known-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        },
+        "widest-line": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write-file-atomic": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "write-json-file": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "detect-indent": "5.0.0",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.1.0",
+            "pify": "3.0.0",
+            "sort-keys": "2.0.0",
+            "write-file-atomic": "2.3.0"
+          },
+          "dependencies": {
+            "detect-indent": {
+              "version": "5.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "write-pkg": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "sort-keys": "2.0.0",
+            "write-json-file": "2.3.0"
+          }
+        },
+        "xdg-basedir": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true
+        }
       }
     },
     "fastify-plugin": {
@@ -224,9 +6116,9 @@
       }
     },
     "fastify-static": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/fastify-static/-/fastify-static-0.6.0.tgz",
-      "integrity": "sha512-1Sr3f4zgQ012rpcM9Ak/H54CJdbcAExF/5iknwM98EaC2Zv+HtwElhmlCyDWI7iVzkgsbg99gtIMAyLnnpbfZA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/fastify-static/-/fastify-static-0.8.0.tgz",
+      "integrity": "sha512-AyRuNUMWwtNPWTeWBrysL6Woi8PY86fGkoCWpAb8UsBocF6gduk/RwtITfj8Vif2CxpBtHZk8xGgm3Ef3PjLvQ==",
       "requires": {
         "fastify-plugin": "0.2.1",
         "send": "0.16.1"
@@ -237,13 +6129,13 @@
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.5.0.tgz",
       "integrity": "sha1-BeMv+5mewtlF3aJ0Yb8IlBQ2RIs=",
       "requires": {
-        "reusify": "1.0.3"
+        "reusify": "1.0.4"
       }
     },
     "find-my-way": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-1.9.0.tgz",
-      "integrity": "sha512-QfFoUnIO29oYx0rxbRZvtbnbPxL6bkSbQYq3eyXz5d1MpBSI69H8+B056ExMY+v6iP4lox+ndEAERs4QSe0VPQ=="
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-1.10.1.tgz",
+      "integrity": "sha512-N3SCui48+ZDvRT6cuarjrhaWP2H2zBXzMENu00G+gLqG0e9rgj2WM2tiVkVU2mRUyZzHZ/9CbzIncFziNLWCGQ=="
     },
     "flatstr": {
       "version": "1.0.5",
@@ -254,14 +6146,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-    },
-    "h2-auto-push": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/h2-auto-push/-/h2-auto-push-0.2.0.tgz",
-      "integrity": "sha512-t3B1LKtLPuaM8DXjdpY0tjYCprW97ZyU/BWOePCgxbucwlbrpmhxp4h4gVmiiVURgkIYJCaNB/YK2kFJHmtKiw==",
-      "requires": {
-        "bloomfilter": "0.0.16"
-      }
     },
     "has-flag": {
       "version": "2.0.0",
@@ -306,18 +6190,18 @@
       "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-2.0.1.tgz",
       "integrity": "sha512-dzUvlQEsh1zUhxv9262O9u8cDQavHt4YUXWQB0XuiYOVq7k+IRJ5VOWu1duFTP4ly/N2eMIiJLyiEOh1iZy0IQ==",
       "requires": {
-        "ajv": "6.0.1",
+        "ajv": "6.1.1",
         "readable-stream": "2.3.3",
         "safe-buffer": "5.1.1"
       }
     },
     "middie": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/middie/-/middie-3.0.0.tgz",
-      "integrity": "sha512-1Hh9aGe5w+73+v+J4wCFlZEiF/a1ATi477rc6Be1qjAeoQHgMapkS2oGqUf+z93jw3ZfC7G34/e6JpTphCfhJQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/middie/-/middie-3.1.0.tgz",
+      "integrity": "sha512-673tjCpr9xbI30cVqNbCvBe1hNS4pNs7Fi8Yp9wPiqX3qTpuRm87uD3aRtH9ji7Gt8SavbX7cwYMqY2muIPMJw==",
       "requires": {
         "path-to-regexp": "2.1.0",
-        "reusify": "1.0.3"
+        "reusify": "1.0.4"
       }
     },
     "mime": {
@@ -352,15 +6236,15 @@
       "integrity": "sha512-dZY7QPCPp5r9cnNuQ955mOv4ZFVDXY/yvqeV7Y1W2PJA3PEFcuow9xKFfJxbBj1pIjOAP+M2B4/7xubmykLrXw=="
     },
     "pino": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-4.10.3.tgz",
-      "integrity": "sha512-IKXK0dcFQYITgOJBEvy1RCI5gUz+VVERXMhIvk5Ie+k9zzrbwXDs38M3H6JhoCHR58exyNpNcEKBrW4JC2P0pg==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-4.10.4.tgz",
+      "integrity": "sha512-icde8CYdLyHW+wLIlobDAnoyuQrDnrK055AkczNCo3sf6SZbJ0As0Xh1XHlWQ2K6qsWW4BdMv4kikL/NAoLjCQ==",
       "requires": {
         "chalk": "2.3.0",
         "fast-json-parse": "1.0.3",
         "fast-safe-stringify": "1.2.3",
         "flatstr": "1.0.5",
-        "pump": "2.0.0",
+        "pump": "2.0.1",
         "quick-format-unescaped": "1.1.2",
         "split2": "2.2.0"
       }
@@ -371,9 +6255,9 @@
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "pump": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.0.tgz",
-      "integrity": "sha512-6MYypjOvtiXhBSTOD0Zs5eNjCGfnqi5mPsCsW+dgKTxrZzQMZQNpBo3XRkLx7id753f3EeyHLBqzqqUymIolgw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "requires": {
         "end-of-stream": "1.4.1",
         "once": "1.4.0"
@@ -407,9 +6291,9 @@
       }
     },
     "reusify": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.3.tgz",
-      "integrity": "sha512-t8ZQIaf4CHxy8mb4QddDuGOygGiSSiJHMZrtrC+4E7urVtqON4dHVwmV0gfiBOE1tt5p1puae6o8e0b3wkr1Ag=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
     "safe-buffer": {
       "version": "5.1.1",

--- a/samples/static-page/package.json
+++ b/samples/static-page/package.json
@@ -16,8 +16,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "argparse": "^1.0.9",
-    "fastify": "^0.39.1",
-    "fastify-auto-push": "^0.2.0",
-    "fastify-static": "^0.6.0"
+    "fastify": "^0.43.0",
+    "fastify-auto-push": "file:../..",
+    "fastify-static": "^0.8.0"
   }
 }

--- a/ts/src/fastify-static.d.ts
+++ b/ts/src/fastify-static.d.ts
@@ -15,13 +15,9 @@
 declare module 'fastify-static' {
 import * as fastify from 'fastify';
 
-  interface PluginOptions {
-  }
-
   function fastifyStatic<HttpServer, HttpRequest, HttpResponse, T>(
-      fn: fastify.Plugin<HttpServer, HttpRequest, HttpResponse, T>,
-      options?: PluginOptions|
-      string): fastify.Plugin<HttpServer, HttpRequest, HttpResponse, T>;
+      instance: fastify.FastifyInstance<HttpServer, HttpRequest, HttpResponse>,
+      opts: T, callback?: (err?: Error) => void): void;
 
   export = fastifyStatic;
 }

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -15,6 +15,7 @@
 import * as cookie from 'cookie';
 import * as fastify from 'fastify';
 import fp from 'fastify-plugin';
+import fastifyStatic from 'fastify-static';
 import * as autoPush from 'h2-auto-push';
 import * as http from 'http';
 import * as http2 from 'http2';
@@ -59,7 +60,7 @@ async function staticServeFn(
   const prefix = opts.prefix || '';
   const ap = new autoPush.AutoPush(root, opts.cacheConfig);
 
-  app.register(require('fastify-static'), opts);
+  app.register(fastifyStatic, opts);
 
   app.addHook('onRequest', async (req, res) => {
     if (isHttp2Request(req)) {

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -14,13 +14,12 @@
 
 import * as cookie from 'cookie';
 import * as fastify from 'fastify';
+import fp from 'fastify-plugin';
 import * as autoPush from 'h2-auto-push';
 import * as http from 'http';
 import * as http2 from 'http2';
 import * as https from 'https';
 import * as stream from 'stream';
-
-import fp = require('fastify-plugin');
 
 export {AssetCacheConfig} from 'h2-auto-push';
 
@@ -48,9 +47,9 @@ function isHttp2Response(res: RawResponse): res is http2.Http2ServerResponse {
 
 const CACHE_COOKIE_KEY = '__ap_cache__';
 
-// TODO use a Symbol if ts behaves
-interface StorePath extends http2.Http2Stream {
-  __req_path?: string;
+const REQ_PATH = Symbol('reqPath');
+interface StorePath extends http2.ServerHttp2Stream {
+  [REQ_PATH]: string;
 }
 
 async function staticServeFn(
@@ -68,16 +67,16 @@ async function staticServeFn(
       const url: string = req.url;
       let reqPath: string = url.split('?')[0];
       reqPath = reqPath.replace(prefix, '');
-      (req.stream as StorePath).__req_path = reqPath;
+      (reqStream as StorePath)[REQ_PATH] = reqPath;
       const cookies = cookie.parse(req.headers['cookie'] as string || '');
       const cacheKey = cookies[CACHE_COOKIE_KEY];
-      const newCacheKey =
+      const {newCacheCookie, pushFn} =
           await ap.preprocessRequest(reqPath, reqStream, cacheKey);
       // TODO(jinwoo): Consider making this persistent across sessions.
       res.setHeader(
-          'set-cookie', cookie.serialize(CACHE_COOKIE_KEY, newCacheKey));
+          'set-cookie', cookie.serialize(CACHE_COOKIE_KEY, newCacheCookie));
 
-      ap.push(reqStream).then(noop, noop);
+      pushFn(reqStream).then(noop, noop);
     }
   });
 
@@ -88,11 +87,10 @@ async function staticServeFn(
       const statusCode = (res as http2.Http2ServerResponse).statusCode;
       if (statusCode === 404) {
         ap.recordRequestPath(
-            resStream.session, (resStream as StorePath).__req_path || '',
-            false);
+            resStream.session, (resStream as StorePath)[REQ_PATH] || '', false);
       } else if (statusCode < 300 && statusCode >= 200) {
         ap.recordRequestPath(
-            resStream.session, (resStream as StorePath).__req_path || '', true);
+            resStream.session, (resStream as StorePath)[REQ_PATH] || '', true);
       }
     }
   });

--- a/ts/test/index-test.ts
+++ b/ts/test/index-test.ts
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import test from 'ava';
-import * as fastify from 'fastify';
-import * as getPort from 'get-port';
+import fastify from 'fastify';
+import getPort from 'get-port';
 import * as http from 'http';
 import * as http2 from 'http2';
 import * as path from 'path';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,9 @@
     "target": "es2017",
     "lib": [
       "es2017"
-    ]
+    ],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
   },
   "include": [
     "ts/**/*.ts"


### PR DESCRIPTION
For that update TypeScript to 2.7.1, which supports constant-named
properties using symbols:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#constant-named-properties

Also update `h2-auto-push` to v0.3.0, which fixes the push list
issue (google/node-h2-auto-push#5).

Update other packages too. And make the sample app use the local
package.