### PR TITLE
chore: release v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-auto-push",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-auto-push",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "HTTP/2 auto-push middleware for fastify",
   "main": "build/src/index.js",
   "types": "build/src/index",

--- a/samples/static-page/package.json
+++ b/samples/static-page/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "argparse": "^1.0.10",
     "fastify": "^1.0.0",
-    "fastify-auto-push": "^0.3.2",
+    "fastify-auto-push": "^0.4.0",
     "fastify-static": "^0.10.1"
   }
 }


### PR DESCRIPTION
Semver major because `h2-auto-push` was upgraded to v0.4.0.

The draft release note is in https://github.com/google/node-fastify-auto-push/releases/tag/untagged-4e283d8431847b1791fd